### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/llvm/scripts/common.py
+++ b/llvm/scripts/common.py
@@ -174,7 +174,7 @@ def gcc(default_cc, fallback_cc):
   try:
     dir_name = os.path.dirname(TSAN_TMP_PREFIX + filename)
     os.makedirs(dir_name)
-    print "makedirs(%s)" % dir_name
+    print "makedirs({0!s})".format(dir_name)
   except OSError:
     pass
   # filename-x86.ll

--- a/unittest/match_output.py
+++ b/unittest/match_output.py
@@ -19,7 +19,7 @@ def matchFile(f, f_re):
 #         print 'match: %s =~ %s' % (line, line_re)
         break
     if not match:
-      print 'no match for: %s' % (line_re)
+      print 'no match for: {0!s}'.format((line_re))
       return False
   return True
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:data-race-test?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:data-race-test?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
